### PR TITLE
Upgrade criu to v2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SOURCES := .dockerignore empty.config
 
 EXTRA := extra/Config.in extra/external.mk \
 	extra/package/criu/Config.in extra/package/criu/criu.mk \
+	extra/package/criu/0001-Remove-quotes-around-CC-for-buildroot.patch \
 	extra/package/ipvsadm/Config.in extra/package/ipvsadm/ipvsadm.mk
 
 base: Dockerfile.base $(SOURCES)

--- a/extra/package/criu/0001-Remove-quotes-around-CC-for-buildroot.patch
+++ b/extra/package/criu/0001-Remove-quotes-around-CC-for-buildroot.patch
@@ -1,0 +1,25 @@
+From e6981ab42647b3d92a93ab0176dd316ef5df59d5 Mon Sep 17 00:00:00 2001
+From: "A.I" <ailis@paw.zone>
+Date: Thu, 10 Mar 2016 14:53:52 +0900
+Subject: [PATCH] Remove quotes around $(CC) for buildroot
+
+---
+ criu/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/criu/Makefile b/criu/Makefile
+index 9f1dd38..144a6df 100644
+--- a/criu/Makefile
++++ b/criu/Makefile
+@@ -64,7 +64,7 @@ ifneq ($(MAKECMDGOALS),clean)
+         ifneq ($(shell sh -c                                                            \
+                         'TMP="$(OUTPUT)$(TMPOUT).$$$$";                                 \
+                         echo "int main(int argc, char *argv[]) { return 0; }" |         \
+-                        "$(CC)" -x c - $(LIBS) -o "$$TMP" > /dev/null 2>&1 && echo y;   \
++                        $(CC) -x c - $(LIBS) -o "$$TMP" > /dev/null 2>&1 && echo y;   \
+                         rm -f "$$TMP"'),y)
+                 $(error "Make sure '$(REQ-LIBS-NAMES)' libraries are installed")
+         endif
+-- 
+2.5.4 (Apple Git-61)
+

--- a/extra/package/criu/Config.in
+++ b/extra/package/criu/Config.in
@@ -2,6 +2,7 @@ config BR2_PACKAGE_CRIU
 	bool "criu"
 	depends on BR2_TOOLCHAIN_USES_GLIBC
 	select BR2_PACKAGE_PROTOBUF_C
+	select BR2_PACKAGE_LIBNL
 	select BR2_PACKAGE_TAR
 	select BR2_PACKAGE_IPROUTE2
 	help

--- a/extra/package/criu/criu.mk
+++ b/extra/package/criu/criu.mk
@@ -4,21 +4,23 @@
 #
 ################################################################################
 
-CRIU_VERSION = v1.7.2
+CRIU_VERSION = v2.0
 CRIU_SITE = $(call github,xemul,criu,$(CRIU_VERSION))
-CRIU_DEPENDENCIES = host-protobuf-c host-protobuf protobuf-c tar iproute2
+CRIU_DEPENDENCIES = host-libcap protobuf-c libnl iproute2 tar
 CRIU_LICENSE = GPLv2 (programs), LGPLv2.1 (libraries)
 CRIU_LICENSE_FILES = COPYING
 
+CRIU_CFLAGS = $(HOST_CFLAGS) --sysroot=$(STAGING_DIR) -I$(STAGING_DIR)/usr/include/libnl3
+CRIU_MAKE_OPTS = PREFIX=/usr CC="$(HOSTCC) $(CRIU_CFLAGS) $(HOST_LDFLAGS)" AR="$(HOSTAR)"
+
 define CRIU_BUILD_CMDS
-	$(RM) $(@D)/protobuf/google/protobuf/descriptor.proto
-	cp $(HOST_DIR)/usr/include/google/protobuf/descriptor.proto $(@D)/protobuf/google/protobuf/
-	$(TARGET_MAKE_ENV) $(MAKE1) CC="$(HOSTCC) $(HOST_CFLAGS) $(HOST_LDFLAGS)" \
-		AR="$(HOSTAR)" -C $(@D) criu
+	$(RM) $(@D)/images/google/protobuf/descriptor.proto
+	cp $(HOST_DIR)/usr/include/google/protobuf/descriptor.proto $(@D)/images/google/protobuf/
+	$(TARGET_MAKE_ENV) $(MAKE1) $(CRIU_MAKE_OPTS) -C $(@D) criu
 endef
 
 define CRIU_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 $(@D)/criu $(TARGET_DIR)/usr/sbin
+	$(TARGET_MAKE_ENV) $(MAKE1) $(CRIU_MAKE_OPTS) -C $(@D) DESTDIR=$(TARGET_DIR) install-criu
 endef
 
 $(eval $(generic-package))


### PR DESCRIPTION
```
  CC       arch/x86/cpu.o
In file included from /build/buildroot/output/build/criu-v2.0/criu/arch/x86/include/asm/types.h:10:0,
                 from arch/x86/cpu.c:10:
/build/buildroot/output/build/criu-v2.0/criu/arch/x86/include/asm/prlimit.h:11:12: error: conflicting types for 'prlimit'
 extern int prlimit(pid_t pid, int resource, const struct rlimit *new_rlimit, struct rlimit *old_rlimit);
            ^
In file included from /usr/include/features.h:374:0,
                 from /usr/include/stdio.h:27,
                 from arch/x86/cpu.c:1:
/usr/include/x86_64-linux-gnu/bits/resource.h:313:12: note: previous declaration of 'prlimit' was here
 extern int __REDIRECT_NTH (prlimit, (__pid_t __pid,
            ^
make[3]: *** [arch/x86/cpu.o] Error 1
```
